### PR TITLE
Add frontend and backend scaffolding for personal blog (React + Spring Boot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-readme
+# 个人博客（React + Spring Cloud）
+
+该项目包含前后端分离的个人博客示例：
+
+- 前端：React + Vite
+- 后端：Spring Boot（Spring Cloud 架构可扩展）
+- 中间件：MySQL + Redis + Kafka
+
+## 目录结构
+
+- `frontend/` React 前端
+- `backend/` Spring Boot 后端
+
+## 后端启动
+
+1. 准备 MySQL、Redis、Kafka 服务。
+2. 修改 `backend/src/main/resources/application.yml` 中的连接信息。
+3. 启动服务：
+
+```bash
+cd backend
+./mvnw spring-boot:run
+```
+
+## 前端启动
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## 功能概览
+
+- 登录/注册（JWT）
+- 权限校验（ROLE_AUTHOR）
+- 文章发布与列表/详情
+- 浏览量与点赞量统计
+- 评论列表与发布

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>blog-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>blog-service</name>
+    <description>Personal blog service</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <jjwt.version>0.11.5</jjwt.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/example/blog/BlogApplication.java
+++ b/backend/src/main/java/com/example/blog/BlogApplication.java
@@ -1,0 +1,11 @@
+package com.example.blog;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BlogApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BlogApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/example/blog/controller/AuthController.java
+++ b/backend/src/main/java/com/example/blog/controller/AuthController.java
@@ -1,0 +1,52 @@
+package com.example.blog.controller;
+
+import com.example.blog.domain.User;
+import com.example.blog.service.AuthService;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public TokenResponse login(@RequestBody LoginRequest request) {
+        String token = authService.login(request.username(), request.password());
+        return new TokenResponse(token);
+    }
+
+    @PostMapping("/register")
+    public UserResponse register(@RequestBody LoginRequest request) {
+        User user = authService.register(request.username(), request.password());
+        return new UserResponse(user.getId(), user.getUsername());
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ErrorResponse handleAuthError(IllegalArgumentException ex) {
+        return new ErrorResponse(ex.getMessage());
+    }
+
+    public record LoginRequest(@NotBlank String username, @NotBlank String password) {
+    }
+
+    public record TokenResponse(String token) {
+    }
+
+    public record UserResponse(Long id, String username) {
+    }
+
+    public record ErrorResponse(String message) {
+    }
+}

--- a/backend/src/main/java/com/example/blog/controller/CommentController.java
+++ b/backend/src/main/java/com/example/blog/controller/CommentController.java
@@ -1,0 +1,56 @@
+package com.example.blog.controller;
+
+import com.example.blog.domain.Comment;
+import com.example.blog.service.CommentService;
+import java.security.Principal;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts/{postId}/comments")
+public class CommentController {
+    private final CommentService commentService;
+
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @GetMapping
+    public List<CommentResponse> list(@PathVariable Long postId) {
+        return commentService.listComments(postId).stream()
+                .map(CommentResponse::from)
+                .toList();
+    }
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommentResponse create(@PathVariable Long postId,
+                                  @RequestBody CommentRequest request,
+                                  Principal principal) {
+        Comment comment = commentService.addComment(postId, principal.getName(), request.content());
+        return CommentResponse.from(comment);
+    }
+
+    public record CommentRequest(String content) {
+    }
+
+    public record CommentResponse(Long id, String author, String content, String createdAt) {
+        static CommentResponse from(Comment comment) {
+            return new CommentResponse(
+                    comment.getId(),
+                    comment.getAuthor().getUsername(),
+                    comment.getContent(),
+                    comment.getCreatedAt().toString()
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/example/blog/controller/PostController.java
+++ b/backend/src/main/java/com/example/blog/controller/PostController.java
@@ -1,0 +1,77 @@
+package com.example.blog.controller;
+
+import com.example.blog.domain.Post;
+import com.example.blog.service.PostService;
+import java.security.Principal;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts")
+public class PostController {
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    @GetMapping
+    public List<PostSummary> list() {
+        return postService.listPosts().stream()
+                .map(PostSummary::from)
+                .toList();
+    }
+
+    @GetMapping("/{id}")
+    public PostDetail detail(@PathVariable Long id) {
+        return PostDetail.from(postService.getPost(id));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('AUTHOR')")
+    @ResponseStatus(HttpStatus.CREATED)
+    public PostDetail create(@RequestBody PostRequest request, Principal principal) {
+        Post post = postService.createPost(request.title(), request.content(), principal.getName());
+        return PostDetail.from(post);
+    }
+
+    @PostMapping("/{id}/view")
+    public PostDetail view(@PathVariable Long id) {
+        return PostDetail.from(postService.incrementViews(id));
+    }
+
+    @PostMapping("/{id}/like")
+    public PostDetail like(@PathVariable Long id) {
+        return PostDetail.from(postService.likePost(id));
+    }
+
+    public record PostRequest(String title, String content) {
+    }
+
+    public record PostSummary(Long id, String title, long viewCount, long likeCount) {
+        static PostSummary from(Post post) {
+            return new PostSummary(post.getId(), post.getTitle(), post.getViewCount(), post.getLikeCount());
+        }
+    }
+
+    public record PostDetail(Long id, String title, String content, long viewCount, long likeCount, String author) {
+        static PostDetail from(Post post) {
+            return new PostDetail(
+                    post.getId(),
+                    post.getTitle(),
+                    post.getContent(),
+                    post.getViewCount(),
+                    post.getLikeCount(),
+                    post.getAuthor().getUsername()
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/example/blog/domain/Comment.java
+++ b/backend/src/main/java/com/example/blog/domain/Comment.java
@@ -1,0 +1,74 @@
+package com.example.blog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "comments")
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private Instant createdAt = Instant.now();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+
+    public void setPost(Post post) {
+        this.post = post;
+    }
+
+    public User getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/blog/domain/Post.java
+++ b/backend/src/main/java/com/example/blog/domain/Post.java
@@ -1,0 +1,95 @@
+package com.example.blog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "posts")
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false)
+    private long viewCount = 0;
+
+    @Column(nullable = false)
+    private long likeCount = 0;
+
+    @Column(nullable = false)
+    private Instant createdAt = Instant.now();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public User getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+
+    public long getViewCount() {
+        return viewCount;
+    }
+
+    public void setViewCount(long viewCount) {
+        this.viewCount = viewCount;
+    }
+
+    public long getLikeCount() {
+        return likeCount;
+    }
+
+    public void setLikeCount(long likeCount) {
+        this.likeCount = likeCount;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/blog/domain/User.java
+++ b/backend/src/main/java/com/example/blog/domain/User.java
@@ -1,0 +1,65 @@
+package com.example.blog.domain;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "role")
+    private Set<String> roles = new HashSet<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+}

--- a/backend/src/main/java/com/example/blog/repository/CommentRepository.java
+++ b/backend/src/main/java/com/example/blog/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.example.blog.repository;
+
+import com.example.blog.domain.Comment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByPostIdOrderByCreatedAtAsc(Long postId);
+}

--- a/backend/src/main/java/com/example/blog/repository/PostRepository.java
+++ b/backend/src/main/java/com/example/blog/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.example.blog.repository;
+
+import com.example.blog.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/backend/src/main/java/com/example/blog/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/blog/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.blog.repository;
+
+import com.example.blog.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/backend/src/main/java/com/example/blog/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/blog/security/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.example.blog.security;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                Claims claims = jwtUtil.parseClaims(token);
+                String username = claims.getSubject();
+                Object rolesClaim = claims.get("roles");
+                List<String> roles = rolesClaim instanceof List<?> list
+                        ? list.stream().map(Object::toString).collect(Collectors.toList())
+                        : List.of();
+                Collection<GrantedAuthority> authorities = roles.stream()
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(username, token, authorities);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception ignored) {
+                SecurityContextHolder.clearContext();
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/example/blog/security/JwtUtil.java
+++ b/backend/src/main/java/com/example/blog/security/JwtUtil.java
@@ -1,0 +1,45 @@
+package com.example.blog.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+    private final SecretKey secretKey;
+    private final long expirationMinutes;
+
+    public JwtUtil(@Value("${app.jwt.secret}") String secret,
+                   @Value("${app.jwt.expiration-minutes}") long expirationMinutes) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMinutes = expirationMinutes;
+    }
+
+    public String generateToken(String username, List<String> roles) {
+        Instant now = Instant.now();
+        Instant expiry = now.plusSeconds(expirationMinutes * 60);
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("roles", roles)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(expiry))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/backend/src/main/java/com/example/blog/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/blog/security/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.example.blog.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/**", "/api/posts", "/api/posts/*", "/api/posts/*/comments").permitAll()
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/backend/src/main/java/com/example/blog/service/AuthService.java
+++ b/backend/src/main/java/com/example/blog/service/AuthService.java
@@ -1,0 +1,41 @@
+package com.example.blog.service;
+
+import com.example.blog.domain.User;
+import com.example.blog.repository.UserRepository;
+import com.example.blog.security.JwtUtil;
+import java.util.List;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public String login(String username, String rawPassword) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
+        if (!passwordEncoder.matches(rawPassword, user.getPasswordHash())) {
+            throw new IllegalArgumentException("Invalid credentials");
+        }
+        return jwtUtil.generateToken(user.getUsername(), List.copyOf(user.getRoles()));
+    }
+
+    public User register(String username, String rawPassword) {
+        if (userRepository.findByUsername(username).isPresent()) {
+            throw new IllegalArgumentException("Username already exists");
+        }
+        User user = new User();
+        user.setUsername(username);
+        user.setPasswordHash(passwordEncoder.encode(rawPassword));
+        user.getRoles().add("ROLE_AUTHOR");
+        return userRepository.save(user);
+    }
+}

--- a/backend/src/main/java/com/example/blog/service/CommentService.java
+++ b/backend/src/main/java/com/example/blog/service/CommentService.java
@@ -1,0 +1,43 @@
+package com.example.blog.service;
+
+import com.example.blog.domain.Comment;
+import com.example.blog.domain.Post;
+import com.example.blog.domain.User;
+import com.example.blog.repository.CommentRepository;
+import com.example.blog.repository.PostRepository;
+import com.example.blog.repository.UserRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    public CommentService(CommentRepository commentRepository,
+                          PostRepository postRepository,
+                          UserRepository userRepository) {
+        this.commentRepository = commentRepository;
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+    }
+
+    public List<Comment> listComments(Long postId) {
+        return commentRepository.findAllByPostIdOrderByCreatedAtAsc(postId);
+    }
+
+    @Transactional
+    public Comment addComment(Long postId, String username, String content) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        User author = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("Author not found"));
+        Comment comment = new Comment();
+        comment.setPost(post);
+        comment.setAuthor(author);
+        comment.setContent(content);
+        return commentRepository.save(comment);
+    }
+}

--- a/backend/src/main/java/com/example/blog/service/PostService.java
+++ b/backend/src/main/java/com/example/blog/service/PostService.java
@@ -1,0 +1,69 @@
+package com.example.blog.service;
+
+import com.example.blog.domain.Post;
+import com.example.blog.domain.User;
+import com.example.blog.repository.PostRepository;
+import com.example.blog.repository.UserRepository;
+import java.util.List;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PostService {
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public PostService(PostRepository postRepository,
+                       UserRepository userRepository,
+                       StringRedisTemplate stringRedisTemplate,
+                       KafkaTemplate<String, String> kafkaTemplate) {
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public List<Post> listPosts() {
+        return postRepository.findAll();
+    }
+
+    public Post getPost(Long id) {
+        return postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+    }
+
+    @Transactional
+    public Post createPost(String title, String content, String username) {
+        User author = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("Author not found"));
+        Post post = new Post();
+        post.setTitle(title);
+        post.setContent(content);
+        post.setAuthor(author);
+        Post saved = postRepository.save(post);
+        kafkaTemplate.send("post-events", "created:" + saved.getId());
+        return saved;
+    }
+
+    @Transactional
+    public Post incrementViews(Long id) {
+        Post post = getPost(id);
+        post.setViewCount(post.getViewCount() + 1);
+        stringRedisTemplate.opsForValue().increment("post:view:" + id);
+        kafkaTemplate.send("post-events", "view:" + id);
+        return postRepository.save(post);
+    }
+
+    @Transactional
+    public Post likePost(Long id) {
+        Post post = getPost(id);
+        post.setLikeCount(post.getLikeCount() + 1);
+        stringRedisTemplate.opsForValue().increment("post:like:" + id);
+        kafkaTemplate.send("post-events", "like:" + id);
+        return postRepository.save(post);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/blog?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+    username: blog
+    password: blog
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  kafka:
+    bootstrap-servers: localhost:9092
+
+app:
+  jwt:
+    secret: change-me-in-prod-change-me-in-prod
+    expiration-minutes: 120

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>个人博客</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "personal-blog",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.11"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,37 @@
+import { Link, Route, Routes } from 'react-router-dom';
+import LoginPage from './pages/LoginPage.jsx';
+import PostListPage from './pages/PostListPage.jsx';
+import PostDetailPage from './pages/PostDetailPage.jsx';
+import PostEditorPage from './pages/PostEditorPage.jsx';
+import { useAuth } from './components/useAuth.js';
+
+export default function App() {
+  const { token, logout } = useAuth();
+
+  return (
+    <div className="app">
+      <header className="app-header">
+        <Link to="/" className="logo">个人博客</Link>
+        <nav>
+          <Link to="/">文章</Link>
+          <Link to="/editor">发布</Link>
+        </nav>
+        <div className="auth-actions">
+          {token ? (
+            <button type="button" onClick={logout}>退出</button>
+          ) : (
+            <Link to="/login">登录</Link>
+          )}
+        </div>
+      </header>
+      <main>
+        <Routes>
+          <Route path="/" element={<PostListPage />} />
+          <Route path="/posts/:id" element={<PostDetailPage />} />
+          <Route path="/editor" element={<PostEditorPage />} />
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,19 @@
+export async function apiRequest(path, options = {}) {
+  const token = localStorage.getItem('blog_token');
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {})
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const response = await fetch(path, { ...options, headers });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: '请求失败' }));
+    throw new Error(error.message || '请求失败');
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  return response.json();
+}

--- a/frontend/src/components/useAuth.js
+++ b/frontend/src/components/useAuth.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const storageKey = 'blog_token';
+
+export function useAuth() {
+  const [token, setToken] = useState(() => localStorage.getItem(storageKey));
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem(storageKey, token);
+    } else {
+      localStorage.removeItem(storageKey);
+    }
+  }, [token]);
+
+  const logout = () => setToken(null);
+
+  return { token, setToken, logout };
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import './styles/app.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiRequest } from '../api/client.js';
+import { useAuth } from '../components/useAuth.js';
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const { setToken } = useAuth();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    try {
+      const data = await apiRequest('/api/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ username, password })
+      });
+      setToken(data.token);
+      navigate('/');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <section className="card">
+      <h1>登录</h1>
+      <form onSubmit={handleSubmit} className="form">
+        <label>
+          用户名
+          <input value={username} onChange={(e) => setUsername(e.target.value)} required />
+        </label>
+        <label>
+          密码
+          <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        </label>
+        {error && <p className="error">{error}</p>}
+        <button type="submit">登录</button>
+      </form>
+      <p className="hint">默认注册接口：/api/auth/register</p>
+    </section>
+  );
+}

--- a/frontend/src/pages/PostDetailPage.jsx
+++ b/frontend/src/pages/PostDetailPage.jsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { apiRequest } from '../api/client.js';
+
+export default function PostDetailPage() {
+  const { id } = useParams();
+  const [post, setPost] = useState(null);
+  const [comments, setComments] = useState([]);
+  const [comment, setComment] = useState('');
+  const [error, setError] = useState('');
+
+  const refresh = async () => {
+    try {
+      const detail = await apiRequest(`/api/posts/${id}`);
+      setPost(detail);
+      const list = await apiRequest(`/api/posts/${id}/comments`);
+      setComments(list);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  useEffect(() => {
+    apiRequest(`/api/posts/${id}/view`, { method: 'POST' }).catch(() => null);
+    refresh();
+  }, [id]);
+
+  const handleLike = async () => {
+    try {
+      const updated = await apiRequest(`/api/posts/${id}/like`, { method: 'POST' });
+      setPost(updated);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleComment = async (event) => {
+    event.preventDefault();
+    setError('');
+    try {
+      await apiRequest(`/api/posts/${id}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ content: comment })
+      });
+      setComment('');
+      refresh();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  if (!post) {
+    return <p>加载中...</p>;
+  }
+
+  return (
+    <section className="card">
+      <h1>{post.title}</h1>
+      <p className="meta">作者：{post.author}</p>
+      <p>{post.content}</p>
+      <div className="meta">
+        <span>浏览 {post.viewCount}</span>
+        <span>点赞 {post.likeCount}</span>
+        <button type="button" onClick={handleLike}>点赞</button>
+      </div>
+      {error && <p className="error">{error}</p>}
+      <section className="comment-section">
+        <h2>评论</h2>
+        <form onSubmit={handleComment} className="form">
+          <textarea value={comment} onChange={(e) => setComment(e.target.value)} required />
+          <button type="submit">发表评论</button>
+        </form>
+        <ul className="comment-list">
+          {comments.map((item) => (
+            <li key={item.id}>
+              <p className="meta">{item.author} · {item.createdAt}</p>
+              <p>{item.content}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </section>
+  );
+}

--- a/frontend/src/pages/PostEditorPage.jsx
+++ b/frontend/src/pages/PostEditorPage.jsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiRequest } from '../api/client.js';
+
+export default function PostEditorPage() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    try {
+      const post = await apiRequest('/api/posts', {
+        method: 'POST',
+        body: JSON.stringify({ title, content })
+      });
+      navigate(`/posts/${post.id}`);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <section className="card">
+      <h1>发布文章</h1>
+      <form onSubmit={handleSubmit} className="form">
+        <label>
+          标题
+          <input value={title} onChange={(e) => setTitle(e.target.value)} required />
+        </label>
+        <label>
+          正文
+          <textarea value={content} onChange={(e) => setContent(e.target.value)} required />
+        </label>
+        {error && <p className="error">{error}</p>}
+        <button type="submit">发布</button>
+      </form>
+      <p className="hint">需要登录且拥有 ROLE_AUTHOR 权限。</p>
+    </section>
+  );
+}

--- a/frontend/src/pages/PostListPage.jsx
+++ b/frontend/src/pages/PostListPage.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { apiRequest } from '../api/client.js';
+
+export default function PostListPage() {
+  const [posts, setPosts] = useState([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    apiRequest('/api/posts')
+      .then(setPosts)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <section>
+      <h1>最新文章</h1>
+      {error && <p className="error">{error}</p>}
+      <div className="post-list">
+        {posts.map((post) => (
+          <article key={post.id} className="card">
+            <h2>
+              <Link to={`/posts/${post.id}`}>{post.title}</Link>
+            </h2>
+            <div className="meta">
+              <span>浏览 {post.viewCount}</span>
+              <span>点赞 {post.likeCount}</span>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1,0 +1,106 @@
+:root {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  color: #1b1f24;
+  background: #f5f7fb;
+}
+
+body {
+  margin: 0;
+}
+
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.app-header nav {
+  display: flex;
+  gap: 16px;
+}
+
+.logo {
+  font-weight: 700;
+  text-decoration: none;
+  color: inherit;
+}
+
+.card {
+  background: #ffffff;
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 10px 20px rgba(13, 23, 41, 0.08);
+  margin-bottom: 24px;
+}
+
+.form {
+  display: grid;
+  gap: 16px;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+}
+
+input,
+textarea {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #d3dae6;
+  font-size: 14px;
+}
+
+button {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 8px;
+  background: #2f6fed;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #1f56c2;
+}
+
+.meta {
+  display: flex;
+  gap: 12px;
+  color: #667085;
+  font-size: 13px;
+  align-items: center;
+}
+
+.post-list {
+  display: grid;
+  gap: 16px;
+}
+
+.error {
+  color: #b42318;
+}
+
+.hint {
+  font-size: 12px;
+  color: #667085;
+}
+
+.comment-section {
+  margin-top: 32px;
+}
+
+.comment-list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:8080'
+    }
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide a minimal full-stack personal blog scaffold with front-end and back-end separated for quick development and demo purposes.
- Implement JWT-based authentication and role-based access so authors can publish while public users can read posts and comments.
- Include hooks for Redis and Kafka to support counters and event publishing without coupling business logic to specific middleware in the scaffold.

### Description
- Add a Spring Boot backend with domain entities (`User`, `Post`, `Comment`), JPA repositories, services (`AuthService`, `PostService`, `CommentService`), and REST controllers (`AuthController`, `PostController`, `CommentController`).
- Add JWT security pieces: `JwtUtil`, `JwtAuthenticationFilter`, and `SecurityConfig`, and include `jjwt` dependencies and `spring-boot-starter-validation` in `pom.xml`.
- Wire in Redis and Kafka usage points in `PostService` for incrementing counters and sending events, and provide example configuration in `backend/src/main/resources/application.yml`.
- Add a React + Vite frontend under `frontend/` with routing and pages (`PostListPage`, `PostDetailPage`, `PostEditorPage`, `LoginPage`), an API client (`api/client.js`), an auth hook (`useAuth`), styles, and `vite.config.js`, and document run instructions in `README.md`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964e260d288832bb1eb32ac7311a0df)